### PR TITLE
Add an example Value Index.

### DIFF
--- a/armor-base/src/main/java/com/rapid7/armor/columnfile/ColumnFileListener.java
+++ b/armor-base/src/main/java/com/rapid7/armor/columnfile/ColumnFileListener.java
@@ -6,6 +6,15 @@ import com.rapid7.armor.meta.ColumnMetadata;
 
 @FunctionalInterface
 public interface ColumnFileListener {
+  /**
+   * Listener callback. For each section of the column file other than the metadata, this will be called.
+   * @param armorSection file section type
+   * @param metadata metadata information for this column file.
+   * @param inputStream data to be read.
+   * @param compressedLength if the data is compressed, this value will be > 0. If uncompressed, value will be 0.
+   * @param uncompressedLength the uncompressed length of the data. if compressedLength is 0, this is the number of bytes available to read.
+   * @return number of bytes read by this function from inputStream . For backward compatibility, function should return 0 bytes for unhandled @{ColumnFileSection}s, such as unknown types.
+   */
   int columnFileSection(
       ColumnFileSection armorSection, ColumnMetadata metadata, DataInputStream inputStream, int compressedLength, int uncompressedLength);
 }

--- a/armor-base/src/main/java/com/rapid7/armor/columnfile/ColumnFileReader.java
+++ b/armor-base/src/main/java/com/rapid7/armor/columnfile/ColumnFileReader.java
@@ -95,14 +95,16 @@ public class ColumnFileReader {
       int readBytes = 0;
       if (entry.sectionType == ColumnFileSection.METADATA) {
         readBytes = readMetadata(dataInputStream);
-      } else
-      {
+      } else {
         readBytes = readSection(dataInputStream, listener, entry.sectionType);
       }
+
       totalBytesRead += readBytes;
     }
   }
 
+  // Reads the section by calling back to the listener, if the listener exists.
+  // listener must return the # of bytes it has read from the dataInputStream.
   private int readSection(DataInputStream dataInputStream, ColumnFileListener listener, ColumnFileSection sectionType)
      throws IOException
   {

--- a/armor-base/src/main/java/com/rapid7/armor/columnfile/ColumnFileSection.java
+++ b/armor-base/src/main/java/com/rapid7/armor/columnfile/ColumnFileSection.java
@@ -9,7 +9,8 @@ public enum ColumnFileSection {
   ENTITY_DICTIONARY(2),
   VALUE_DICTIONARY(3),
   ENTITY_INDEX(4),
-  ROWGROUP(5);
+  ROWGROUP(5),
+  VALUE_INDEX(6);
 
   private final int sectionID;
 

--- a/armor-base/src/main/java/com/rapid7/armor/schema/DataType.java
+++ b/armor-base/src/main/java/com/rapid7/armor/schema/DataType.java
@@ -207,4 +207,50 @@ public enum DataType {
       rowCount++;
     }
   }
+
+  public Number fromString(String key)
+  {
+    if ("null".equals(key)) {
+      return null;
+    } else {
+      switch (this) {
+        case LONG:
+        case DATETIME:
+          return Long.parseLong(key);
+        case FLOAT:
+          return Float.parseFloat(key);
+        case INTEGER:
+        case STRING:
+          return Integer.parseInt(key);
+        case BOOLEAN:
+          return Byte.parseByte(key);
+        case DOUBLE:
+          return Double.parseDouble(key);
+      }
+    }
+    throw new IllegalStateException("unknown object type");
+  }
+
+  public String toString(Object val) {
+    if (val == null) {
+      return "null";
+    } else {
+      switch (this) {
+        case LONG:
+        case DATETIME:
+          return Long.toString((Long) val);
+        case FLOAT:
+          return Float.toString((Float) val);
+        case INTEGER:
+        case STRING:
+          return Integer.toString((Integer) val);
+        case BOOLEAN:
+          return Byte.toString((Byte) val);
+        case DOUBLE:
+          return Double.toString((Double) val);
+      }
+    }
+    throw new IllegalStateException("unknown object type");
+  }
+
 }

--- a/armor-write/src/main/java/com/rapid7/armor/write/component/IndexUpdater.java
+++ b/armor-write/src/main/java/com/rapid7/armor/write/component/IndexUpdater.java
@@ -1,0 +1,8 @@
+package com.rapid7.armor.write.component;
+
+public interface IndexUpdater
+{
+   void add(Number value, Integer entityId, Integer rowCount);
+
+   void finish();
+}

--- a/armor-write/src/main/java/com/rapid7/armor/write/component/ValueIndexWriter.java
+++ b/armor-write/src/main/java/com/rapid7/armor/write/component/ValueIndexWriter.java
@@ -1,0 +1,83 @@
+package com.rapid7.armor.write.component;
+
+import com.rapid7.armor.schema.DataType;
+import com.rapid7.armor.shard.ColumnShardId;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ *
+ */
+public class ValueIndexWriter implements Component, IndexUpdater {
+  private final ColumnShardId columnShardId;
+  private final DataType dataType;
+  private Map<Number, Set<Integer>> valToEntities = new HashMap<>();
+  private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  
+  public ValueIndexWriter(ColumnShardId columnShardId) {
+    this.columnShardId = columnShardId;
+    this.dataType = columnShardId.getColumnId().dataType();
+  }
+
+  public ValueIndexWriter(ColumnShardId columnShardId, byte[] json) throws IOException {
+    this(columnShardId);
+    @SuppressWarnings("unchecked")
+    Map<String, List<Integer>> map = OBJECT_MAPPER.readValue(json, Map.class);
+    valToEntities = new HashMap<>();
+    int highestSurrogate = -1;
+    for (Map.Entry<String, List<Integer> > e : map.entrySet()) {
+      Number val = dataType.fromString(e.getKey());
+      valToEntities.put(val, new HashSet<>(e.getValue()));
+    }
+  }
+
+  public Map<Number, Set<Integer>> getValToEntities() { return valToEntities; }
+
+  public boolean isEmpty() {
+    return valToEntities.isEmpty();
+  }
+
+  private byte[] toBytes() throws JsonProcessingException {
+    HashMap<String, List<Integer>> serializable = new HashMap<>();
+    for (Map.Entry<Number, Set<Integer>> e : valToEntities.entrySet()) {
+      serializable.put(this.dataType.toString(e.getKey()), new ArrayList<>(e.getValue()));
+    }
+    return OBJECT_MAPPER.writeValueAsBytes(serializable);
+  }
+
+  @Override
+  public InputStream getInputStream() throws IOException {
+    return new ByteArrayInputStream(toBytes());
+  }
+
+  @Override
+  public long getCurrentSize() throws IOException {
+    return toBytes().length;
+  }
+
+
+
+  @Override public void add(Number value, Integer entityId, Integer rowCount)
+  {
+    Set<Integer> entities = this.valToEntities.get(value);
+    if (entities == null) {
+      entities = new HashSet<>();
+      this.valToEntities.put(value, entities);
+    }
+    entities.add(entityId);
+  }
+
+  @Override public void finish()
+  {
+    // don't need to do anything
+  }
+}


### PR DESCRIPTION
For the moment, this is simply a JSON
index that maps values to the Entity ID of entities containing that value,
although it would be simple to extend that to include the row within that
entity as well.

This is a proof of concept for the ability to add additional indices
which might improve query performance.

## Description
<!-- Describe what this change does and why it is needed. -->
<!-- Add JIRA link if applicable -->

## Testing
<!-- Describe how this change was tested -->

<!-- For more information see: https://wiki.corp.rapid7.com/x/eSxMBg -->
